### PR TITLE
Add exif to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN sudo apt-get install apt-transport-https && \
     sudo apt-get update -yq && \
     sudo apt-get install -yq libpng-dev libicu-dev libjpeg62-turbo-dev yarn && \
     sudo docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ && \
-    sudo docker-php-ext-install -j$(nproc) gd pcntl intl zip pdo_mysql && \
+    sudo docker-php-ext-install -j$(nproc) gd pcntl intl zip pdo_mysql exif && \
     sudo wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     sudo rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz


### PR DESCRIPTION
This error has shown up a in our latest builds:

```
#!/bin/bash -eo pipefail
scripts/test/bootstrap.sh
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for spatie/image 1.6.0 -> satisfiable by spatie/image[1.6.0].
    - spatie/image 1.6.0 requires ext-exif * -> the requested PHP extension exif is missing from your system.
  Problem 2
    - spatie/image 1.6.0 requires ext-exif * -> the requested PHP extension exif is missing from your system.
    - spatie/browsershot 3.26.2 requires spatie/image ^1.5.3 -> satisfiable by spatie/image[1.6.0].
    - Installation request for spatie/browsershot 3.26.2 -> satisfiable by spatie/browsershot[3.26.2].
```

https://circleci.com/gh/Vimily/Bonjoro/11501?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link